### PR TITLE
Fix 2 issues in MD

### DIFF
--- a/src/MarkdownGenerator.cpp
+++ b/src/MarkdownGenerator.cpp
@@ -223,7 +223,6 @@ std::string MarkdownGenerator::frontmatter(const Entity& entity) {
   buf << "title: " << title(entity) << std::endl;
   buf << "description: " << line(brief(entity)) << std::endl;
   buf << "generator: doxide" << std::endl;
-  buf << "---" << std::endl;
   buf << std::endl;
   return buf.str();
 }

--- a/src/doxide.cpp
+++ b/src/doxide.cpp
@@ -44,8 +44,8 @@ markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 plugins:
   - search
 extra_css:


### PR DESCRIPTION
1. In latter version of `mkdocs-material`, `material.extensions` should be used instead of `materialx` (there is a warning at build time)
2. The `---` after the `generator: doxide` gets interpreted and results in a useless `<hr>` at the top of every page ;)