### PR TITLE
Add version flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,19 @@ target_include_directories(doxide PRIVATE
     contrib/glob/single_include
     contrib/CLI11/include
 )
+
+# Find the system libyaml
+#
+# Note that on the default packages on linux (arch, etc) and macos/brew
+# do not contain any cmake package config files for libyaml
+# so find_package will error out.
+find_package(yaml QUIET HINTS /usr /usr/lib /usr/local/lib)
+
+option(BUILD_YAML "Build contrib/libyaml" OFF)
+if(BUILD_YAML)
+    add_subdirectory(contrib/libyaml)
+endif()
+
 target_link_libraries(doxide
     yaml
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(doxide
-    VERSION 0.0.0
+    VERSION 0.8.0
     DESCRIPTION "Modern documentation for modern C++"
     HOMEPAGE_URL "https://doxide.org")
 
@@ -41,6 +41,11 @@ target_include_directories(doxide PRIVATE
 )
 target_link_libraries(doxide
     yaml
+)
+
+configure_file(
+    ${CMAKE_SOURCE_DIR}/src/Version.h.in
+    ${CMAKE_SOURCE_DIR}/src/Version.h
 )
 
 include(GNUInstallDirs)

--- a/src/Version.h.in
+++ b/src/Version.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define DOXIDE_VERSION "@PROJECT_VERSION@"

--- a/src/doxide.cpp
+++ b/src/doxide.cpp
@@ -1,4 +1,5 @@
 #include "Driver.hpp"
+#include "Version.h"
 
 void write_file(const std::string& contents,
     const std::filesystem::path& dst) {
@@ -57,6 +58,7 @@ int main(int argc, char** argv) {
       "Output directory.");
   app.add_option("--coverage", driver.coverage,
       "Code coverage file (.gcov or .json).");
+  app.set_version_flag("--version,-v", DOXIDE_VERSION, "Doxide version.");
   app.add_subcommand("init",
       "Initialize configuration files.")->
       fallthrough()->


### PR DESCRIPTION
Adds a --version,-v flag to show the version of application.

- version is pulled the cmake variable`PROJECT_VERSION` set in CMakeLists.txt.

Fixes cmake build on macos; `libyaml` was not properly included.