### PR TITLE
Add 'doxide watch' subcommand.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(doxide
     src/JSONCounter.cpp
     src/JSONGenerator.cpp
     src/MarkdownGenerator.cpp
+    src/SourceWatcher.cpp
     src/YAMLNode.cpp
     src/YAMLParser.cpp
 )

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -8,6 +8,9 @@ Commands are:
 `doxide build`
 :   Build documentation in the output directory.
 
+`doxide watch`
+:   Watch the documentation's source files and rebuild it on changes.
+
 `doxide clean`
 :   Clean the output directory.
 

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -246,7 +246,7 @@ void Driver::watch() {
   MarkdownGenerator generator(output);
 
   for (;;){
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
     
     if (config_watcher.changed()){
       root.clear();

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -243,7 +243,6 @@ void Driver::watch() {
   SourceWatcher watcher = SourceWatcher(files_patterns);
 
   CppParser parser;
-  MarkdownGenerator generator(output);
 
   for (;;){
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
@@ -252,7 +251,6 @@ void Driver::watch() {
       root.clear();
       build();
 
-      generator = MarkdownGenerator(output);
       config_watcher = SourceWatcher(config_file);
       watcher = SourceWatcher(files_patterns);
 
@@ -279,6 +277,7 @@ void Driver::watch() {
     if (!added_files.empty() || !changed_files.empty() || !deleted_files.empty()){
       count();
 
+      MarkdownGenerator generator(output);
       generator.generate(root);
       generator.coverage(root);
       generator.clean();

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -241,7 +241,7 @@ void Driver::watch() {
 
   std::cout << "Start watching" << std::endl;
 
-  SourceWatcher config_watcher = SourceWatcher(config_file);
+  SourceWatcher config_watcher = SourceWatcher(config_file.string());
   SourceWatcher watcher = SourceWatcher(files_patterns);
 
   CppParser parser;
@@ -256,7 +256,7 @@ void Driver::watch() {
       root.clear();
       build();
 
-      config_watcher = SourceWatcher(config_file);
+      config_watcher = SourceWatcher(config_file.string());
       watcher = SourceWatcher(files_patterns);
 
       std::cout << "Done" << std::endl;

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -5,6 +5,9 @@
 #include "GcovCounter.hpp"
 #include "JSONCounter.hpp"
 #include "JSONGenerator.hpp"
+#include "SourceWatcher.hpp"
+
+#include <thread>
 
 /**
  * Contents of initial `doxide.yaml` file.
@@ -232,6 +235,57 @@ void Driver::build() {
   generator.clean();
 }
 
+void Driver::watch() {
+
+  build();
+
+  SourceWatcher config_watcher = SourceWatcher(config_file);
+  SourceWatcher watcher = SourceWatcher(files_patterns);
+
+  CppParser parser;
+  MarkdownGenerator generator(output);
+
+  for (;;){
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    
+    if (config_watcher.changed()){
+      root.clear();
+      build();
+
+      generator = MarkdownGenerator(output);
+      config_watcher = SourceWatcher(config_file);
+      watcher = SourceWatcher(files_patterns);
+
+      continue;
+    }
+
+    auto [added_files, changed_files, deleted_files] = watcher.diff();
+    filenames = watcher.filenames();
+
+    for (const auto& filename: deleted_files) {
+      root.delete_by_predicate([filename](const Entity& e) {return e.path == filename; });
+    }
+    for (const auto& filename: changed_files) {
+      root.delete_by_predicate([filename](const Entity& e) {return e.path == filename; });
+    }
+
+    for (const auto& filename: changed_files) {
+      parser.parse(filename, defines, root);
+    }
+    for (const auto& filename: added_files) {
+      parser.parse(filename, defines, root);
+    }
+
+    if (!added_files.empty() || !changed_files.empty() || !deleted_files.empty()){
+      count();
+
+      generator.generate(root);
+      generator.coverage(root);
+      generator.clean();
+    }
+  }
+}
+
 void Driver::cover() {
   config();
   parse();
@@ -253,18 +307,17 @@ void Driver::clean() {
 
 void Driver::config() {
   /* find the configuration file */
-  std::string path;
   if (std::filesystem::exists("doxide.yaml")) {
-    path = "doxide.yaml";
+    config_file = "doxide.yaml";
   } else if (std::filesystem::exists("doxide.yml")) {
-    path = "doxide.yml";
+    config_file = "doxide.yml";
   } else if (std::filesystem::exists("doxide.json")) {
-    path = "doxide.json";
+    config_file = "doxide.json";
   }
 
   /* parse build configuration file */
   YAMLParser parser;
-  YAMLNode yaml = parser.parse(path);
+  YAMLNode yaml = parser.parse(config_file);
 
   if (yaml.has("title")) {
     if (yaml.isValue("title")) {
@@ -313,6 +366,7 @@ void Driver::config() {
     for (auto& node : yaml.sequence("files")) {
       if (node->isValue()) {
         auto& pattern = node->value();
+        files_patterns.push_back(pattern);
         auto paths = glob::rglob(pattern);
         if (paths.empty()) {
           /* print warning if pattern does not contain a wildcard '*' */

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -27,6 +27,11 @@ public:
   void build();
 
   /**
+   * Watch and build documentation on changes.
+   */
+  void watch();
+
+  /**
    * Output line coverage information.
    */
   void cover();
@@ -81,6 +86,16 @@ private:
    * Root entity.
    */
   Entity root;
+
+  /**
+   * Configuration file path.
+   */
+  std::filesystem::path config_file;
+
+  /**
+   * Files patterns.
+   */
+  std::list<std::string> files_patterns;
 
   /**
    * Macro definitions.

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -209,3 +209,30 @@ std::list<Entity*> Entity::get(std::filesystem::path& path) {
 void Entity::clear() {
   *this = Entity();
 }
+
+void Entity::delete_by_predicate(std::function<bool(const Entity&)> p){
+	std::erase_if(namespaces, p);
+	std::erase_if(groups, p);
+	std::erase_if(types, p);
+	std::erase_if(concepts, p);
+	std::erase_if(variables, p);
+	std::erase_if(functions, p);
+	std::erase_if(operators, p);
+	std::erase_if(enums, p);
+	std::erase_if(macros, p);
+	std::erase_if(dirs, p);
+	std::erase_if(files, p);
+
+	auto r = [p](Entity& e){ e.delete_by_predicate(p); };
+        std::for_each(namespaces.begin(), namespaces.end(), r);
+	std::for_each(groups.begin(), groups.end(), r);
+	std::for_each(types.begin(), types.end(), r);
+	std::for_each(concepts.begin(), concepts.end(), r);
+        std::for_each(variables.begin(), variables.end(), r);
+        std::for_each(functions.begin(), functions.end(), r);
+        std::for_each(operators.begin(), operators.end(), r);
+	std::for_each(enums.begin(), enums.end(), r);
+	std::for_each(macros.begin(), macros.end(), r);
+	std::for_each(dirs.begin(), dirs.end(), r);
+	std::for_each(files.begin(), files.end(), r);
+}

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -83,6 +83,13 @@ struct Entity {
   void clear();
 
   /**
+   * Recursively delete all child entities that satisfy the predicate.
+   *
+   * @param p Predicate.
+   */
+  void delete_by_predicate(std::function<bool(const Entity&)> p);
+
+  /**
    * Child namespaces.
    */
   list_type namespaces;

--- a/src/SourceWatcher.cpp
+++ b/src/SourceWatcher.cpp
@@ -1,0 +1,62 @@
+#include "SourceWatcher.hpp"
+
+SourceWatcher::SourceWatcher(std::list<std::string> patterns): patterns{patterns}{
+  for (auto pattern : patterns){
+    auto paths = glob::rglob(pattern);
+    for (auto& file : paths) {
+      tracked_files[file.string()] = std::filesystem::last_write_time(file);
+    }
+  }
+}
+
+SourceWatcher::SourceWatcher(std::string pattern): SourceWatcher(std::list<std::string>{pattern}){
+  //
+}
+
+std::tuple<std::unordered_set<std::filesystem::path>,
+           std::unordered_set<std::filesystem::path>,
+           std::unordered_set<std::filesystem::path>> SourceWatcher::diff(){
+  std::unordered_set<std::filesystem::path> added_files;
+  std::unordered_set<std::filesystem::path> modified_files;
+  std::unordered_set<std::filesystem::path> deleted_files = filenames();
+
+  for (auto pattern : patterns){
+    auto paths = glob::rglob(pattern);
+    for(auto& file : paths) {
+      auto last_write_time = std::filesystem::last_write_time(file);
+
+      /* Remove this file from the deleted files set as it still exists*/
+      deleted_files.erase(file.string());
+
+      /* Check file creation and modification */
+      if(! tracked_files.contains(file.string())) {
+        added_files.insert(file.string());
+      } else if(tracked_files[file.string()] != last_write_time) {
+        modified_files.insert(file.string());
+      }
+
+      /* Update the timestamp */
+      tracked_files[file.string()] = last_write_time;
+    }
+  }
+
+  /* Remove deleted files from the tracked_files map */
+  for (auto deleted_file : deleted_files){
+      tracked_files.erase(deleted_file);
+  }
+
+  return {added_files, modified_files, deleted_files};
+}
+
+bool SourceWatcher::changed(){
+  auto [added_files, modified_files, deleted_files] = diff();
+  return !added_files.empty() || !modified_files.empty() || !deleted_files.empty();
+}
+
+std::unordered_set<std::filesystem::path> SourceWatcher::filenames(){
+  std::unordered_set<std::filesystem::path> filenames;
+  for (auto pairs : tracked_files) {
+    auto result = filenames.insert(pairs.first);
+  }
+  return filenames;
+}

--- a/src/SourceWatcher.hpp
+++ b/src/SourceWatcher.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "doxide.hpp"
+
+#include <filesystem>
+
+/**
+ * Source Watcher.
+ *
+ * Watches for changes of source files. The files to watch are specified by a glob pattern.
+ *
+ * @ingroup developer
+ */
+class SourceWatcher {
+public:
+  /**
+   * Constructor for a list of patterns.
+   *
+   * @param patterns
+   */
+  SourceWatcher(std::list<std::string> patterns);
+
+  /**
+   * Constructor for a single pattern.
+   */
+  SourceWatcher(std::string pattern);
+
+  /**
+   * Check if any of the watched files changed since the last call to `changed()` or `diff()`.
+   */
+  bool changed();
+
+  /**
+   * Check if any of the watched files changed since the last call to `changed()` or `diff()`.
+   *
+   * @return A tuple containing sets of added, modified and deleted file paths.
+   */
+  std::tuple<std::unordered_set<std::filesystem::path>,
+             std::unordered_set<std::filesystem::path>,
+             std::unordered_set<std::filesystem::path>> diff();
+
+  /**
+   * The current source files.
+   *
+   */
+  std::unordered_set<std::filesystem::path> filenames();
+
+private:
+  /**
+   * The patterns to watch.
+   */
+  std::list<std::string> patterns;
+
+  /**
+   * The tracked file paths and their last modification time.
+   */
+  std::unordered_map<std::filesystem::path, std::filesystem::file_time_type> tracked_files;
+};

--- a/src/doxide.cpp
+++ b/src/doxide.cpp
@@ -65,6 +65,10 @@ int main(int argc, char** argv) {
       "Build documentation in output directory.")->
       fallthrough()->
       callback([&]() { driver.build(); });
+  app.add_subcommand("watch",
+      "Watch the documentation's source files and rebuild it on changes.")->
+      fallthrough()->
+      callback([&]() { driver.watch(); });
   app.add_subcommand("clean",
       "Clean output directory.")->
       fallthrough()->


### PR DESCRIPTION
This PR adds a `doxide watch` subcommand as discussed in #59 which watches the documentation's source files and rebuilds it on changes.

File watching is done by the new class `SourceWatcher` which tracks the last modification time of each source file and is regularly polled to check if any of them has changed.

If a change in the source is detected, all child `Entity`s of the `Entity`  tree originating from a modified or deleted file are removed and all added or modified files are reparsed. This accelerates rebuilds substantially compared to building from scratch.