### PR TITLE
Exit gracefully when trying to build in a directory without configuration file.

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -334,6 +334,8 @@ void Driver::config() {
     config_file = "doxide.yml";
   } else if (std::filesystem::exists("doxide.json")) {
     config_file = "doxide.json";
+  } else {
+    error("No configuration file found.");
   }
 
   /* parse build configuration file */


### PR DESCRIPTION
A small PR to ensure a graceful exit and provide some feedback on why building failed when trying to do it in a directory missing a configuration file.