### PR TITLE
List typedefs on parent page.

### DIFF
--- a/docs/stylesheets/doxide.css
+++ b/docs/stylesheets/doxide.css
@@ -1,12 +1,14 @@
 :root {
   --md-admonition-icon--variable: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.41 3c1.39 2.71 1.94 5.84 1.59 9-.2 3.16-1.3 6.29-3.17 9l-1.53-1c1.61-2.43 2.55-5.2 2.7-8 .34-2.8-.11-5.57-1.3-8l1.71-1M5.17 3 6.7 4C5.09 6.43 4.15 9.2 4 12c-.34 2.8.12 5.57 1.3 8l-1.69 1c-1.4-2.71-1.96-5.83-1.61-9 .2-3.16 1.3-6.29 3.17-9m6.91 7.68 2.32-3.23h2.53l-3.78 5 2.2 4.92h-2.26L11.71 14l-2.43 3.33H6.76l3.9-5.12-2.13-4.76h2.27l1.28 3.23Z"/></svg>');
   --md-admonition-icon--function: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63 4.007 4.007 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38 1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63 1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38Z"/></svg>');
+  --md-admonition-icon--typedef: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M 13.43 7.11 L 13.18 10 H 17 V 12 H 13 L 12.56 17.07 A 1 1 0 0 0 15.287 17.261 L 17.028 17.48 A 1 1 0 0 1 10.57 16.89 L 11 12 H 8 V 10 H 11.17 L 11.44 6.93 Z"/></svg>');
   --md-admonition-icon--concept: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3.75 3.5a.25.25 0 0 0-.25.25v2.062a.75.75 0 1 1-1.5 0V3.75C2 2.783 2.783 2 3.75 2h2.062a.75.75 0 1 1 0 1.5Zm13.688-.75a.75.75 0 0 1 .75-.75h2.062c.966 0 1.75.783 1.75 1.75v2.062a.75.75 0 1 1-1.5 0V3.75a.25.25 0 0 0-.25-.25h-2.062a.75.75 0 0 1-.75-.75ZM2.75 17.438a.75.75 0 0 1 .75.75v2.062c0 .138.112.25.25.25h2.062a.75.75 0 1 1 0 1.5H3.75A1.75 1.75 0 0 1 2 20.25v-2.062a.75.75 0 0 1 .75-.75Zm18.5 0a.75.75 0 0 1 .75.75v2.062A1.75 1.75 0 0 1 20.25 22h-2.062a.75.75 0 1 1 0-1.5h2.062a.25.25 0 0 0 .25-.25v-2.062a.75.75 0 0 1 .75-.75Zm-18.5-8.25a.75.75 0 0 1 .75.75v4.124a.75.75 0 1 1-1.5 0V9.938a.75.75 0 0 1 .75-.75ZM9.188 2.75a.75.75 0 0 1 .75-.75h4.124a.75.75 0 1 1 0 1.5H9.938a.75.75 0 0 1-.75-.75Zm0 18.5a.75.75 0 0 1 .75-.75h4.124a.75.75 0 1 1 0 1.5H9.938a.75.75 0 0 1-.75-.75ZM21.25 9.188a.75.75 0 0 1 .75.75v4.124a.75.75 0 1 1-1.5 0V9.938a.75.75 0 0 1 .75-.75ZM3.75 8.25a.75.75 0 0 1 .75-.75h2a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1-.75-.75Zm5.5 0A.75.75 0 0 1 10 7.5h2A.75.75 0 0 1 12 9h-2a.75.75 0 0 1-.75-.75Zm-1-4.5A.75.75 0 0 1 9 4.5v2a.75.75 0 0 1-1.5 0v-2a.75.75 0 0 1 .75-.75Zm0 5.5A.75.75 0 0 1 9 10v2a.75.75 0 0 1-1.5 0v-2a.75.75 0 0 1 .75-.75Zm0 4.75a.75.75 0 0 1 .75.75v4a.75.75 0 0 1-1.5 0v-4a.75.75 0 0 1 .75-.75ZM14 8.25a.75.75 0 0 1 .75-.75h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1-.75-.75Z"/></svg>');
   --md-admonition-icon--macro: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m5.41 21 .71-4h-4l.35-2h4l1.06-6h-4l.35-2h4l.71-4h2l-.71 4h6l.71-4h2l-.71 4h4l-.35 2h-4l-1.06 6h4l-.35 2h-4l-.71 4h-2l.71-4h-6l-.71 4h-2M9.53 9l-1.06 6h6l1.06-6h-6Z"/></svg>');
 }
 
 .md-typeset .admonition.variable, .md-typeset details.variable,
 .md-typeset .admonition.function, .md-typeset details.function,
+.md-typeset .admonition.typedef, .md-typeset details.typedef,
 .md-typeset .admonition.concept, .md-typeset details.concept,
 .md-typeset .admonition.macro, .md-typeset details.macro {
   border-color: var(--md-default-fg-color--lighter);
@@ -14,6 +16,7 @@
 
 .md-typeset .variable > .admonition-title, .md-typeset .variable > summary,
 .md-typeset .function > .admonition-title, .md-typeset .function > summary,
+.md-typeset .typedef > .admonition-title, .md-typeset .typedef > summary,
 .md-typeset .concept > .admonition-title, .md-typeset .concept > summary,
 .md-typeset .macro > .admonition-title, .md-typeset .macro > summary {
   background-color: var(--md-default-bg-color);
@@ -33,6 +36,13 @@
           mask-image: var(--md-admonition-icon--function);
 }
 
+.md-typeset .typedef > .admonition-title::before,
+.md-typeset .typedef > summary::before {
+  background-color: var(--md-default-fg-color--light);
+  -webkit-mask-image: var(--md-admonition-icon--typedef);
+          mask-image: var(--md-admonition-icon--typedef);
+}
+
 .md-typeset .concept > .admonition-title::before,
 .md-typeset .concept > summary::before {
   background-color: var(--md-default-fg-color--light);
@@ -46,4 +56,3 @@
   -webkit-mask-image: var(--md-admonition-icon--macro);
           mask-image: var(--md-admonition-icon--macro);
 }
-

--- a/src/CppParser.cpp
+++ b/src/CppParser.cpp
@@ -73,7 +73,7 @@ static const char* query_cpp = R""""(
 
   ;; type alias
   (alias_declaration
-      name: (type_identifier) @name) @type
+      name: (type_identifier) @name) @typedef
 
   ;; concept
   (concept_definition

--- a/src/CppParser.cpp
+++ b/src/CppParser.cpp
@@ -69,7 +69,7 @@ static const char* query_cpp = R""""(
 
   ;; typedef
   (type_definition
-       declarator: (type_identifier) @name .) @type
+       declarator: (type_identifier) @name .) @typedef
 
   ;; type alias
   (alias_declaration
@@ -423,6 +423,8 @@ void CppParser::parse(const std::filesystem::path& filename,
           entity.type = EntityType::TEMPLATE;
         } else if (strncmp(name, "type", length) == 0) {
           entity.type = EntityType::TYPE;
+        } else if (strncmp(name, "typedef", length) == 0) {
+          entity.type = EntityType::TYPEDEF;
         } else if (strncmp(name, "concept", length) == 0) {
           entity.type = EntityType::CONCEPT;
         } else if (strncmp(name, "variable", length) == 0) {

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -124,12 +124,14 @@ static const char* init_docs_stylesheets_doxide_css =
 R""""(:root {
   --md-admonition-icon--variable: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.41 3c1.39 2.71 1.94 5.84 1.59 9-.2 3.16-1.3 6.29-3.17 9l-1.53-1c1.61-2.43 2.55-5.2 2.7-8 .34-2.8-.11-5.57-1.3-8l1.71-1M5.17 3 6.7 4C5.09 6.43 4.15 9.2 4 12c-.34 2.8.12 5.57 1.3 8l-1.69 1c-1.4-2.71-1.96-5.83-1.61-9 .2-3.16 1.3-6.29 3.17-9m6.91 7.68 2.32-3.23h2.53l-3.78 5 2.2 4.92h-2.26L11.71 14l-2.43 3.33H6.76l3.9-5.12-2.13-4.76h2.27l1.28 3.23Z"/></svg>');
   --md-admonition-icon--function: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.6 5.29c-1.1-.1-2.07.71-2.17 1.82L13.18 10H16v2h-3l-.44 5.07a3.986 3.986 0 0 1-4.33 3.63 4.007 4.007 0 0 1-3.06-1.87l1.5-1.5c.24.74.9 1.31 1.73 1.38 1.1.1 2.07-.71 2.17-1.82L11 12H8v-2h3.17l.27-3.07c.19-2.2 2.13-3.83 4.33-3.63 1.31.11 2.41.84 3.06 1.87l-1.5 1.5c-.24-.74-.9-1.31-1.73-1.38Z"/></svg>');
+  --md-admonition-icon--typedef: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M 13.43 7.11 L 13.18 10 H 17 V 12 H 13 L 12.56 17.07 A 1 1 0 0 0 15.287 17.261 L 17.028 17.48 A 1 1 0 0 1 10.57 16.89 L 11 12 H 8 V 10 H 11.17 L 11.44 6.93 Z"/></svg>');
   --md-admonition-icon--concept: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3.75 3.5a.25.25 0 0 0-.25.25v2.062a.75.75 0 1 1-1.5 0V3.75C2 2.783 2.783 2 3.75 2h2.062a.75.75 0 1 1 0 1.5Zm13.688-.75a.75.75 0 0 1 .75-.75h2.062c.966 0 1.75.783 1.75 1.75v2.062a.75.75 0 1 1-1.5 0V3.75a.25.25 0 0 0-.25-.25h-2.062a.75.75 0 0 1-.75-.75ZM2.75 17.438a.75.75 0 0 1 .75.75v2.062c0 .138.112.25.25.25h2.062a.75.75 0 1 1 0 1.5H3.75A1.75 1.75 0 0 1 2 20.25v-2.062a.75.75 0 0 1 .75-.75Zm18.5 0a.75.75 0 0 1 .75.75v2.062A1.75 1.75 0 0 1 20.25 22h-2.062a.75.75 0 1 1 0-1.5h2.062a.25.25 0 0 0 .25-.25v-2.062a.75.75 0 0 1 .75-.75Zm-18.5-8.25a.75.75 0 0 1 .75.75v4.124a.75.75 0 1 1-1.5 0V9.938a.75.75 0 0 1 .75-.75ZM9.188 2.75a.75.75 0 0 1 .75-.75h4.124a.75.75 0 1 1 0 1.5H9.938a.75.75 0 0 1-.75-.75Zm0 18.5a.75.75 0 0 1 .75-.75h4.124a.75.75 0 1 1 0 1.5H9.938a.75.75 0 0 1-.75-.75ZM21.25 9.188a.75.75 0 0 1 .75.75v4.124a.75.75 0 1 1-1.5 0V9.938a.75.75 0 0 1 .75-.75ZM3.75 8.25a.75.75 0 0 1 .75-.75h2a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1-.75-.75Zm5.5 0A.75.75 0 0 1 10 7.5h2A.75.75 0 0 1 12 9h-2a.75.75 0 0 1-.75-.75Zm-1-4.5A.75.75 0 0 1 9 4.5v2a.75.75 0 0 1-1.5 0v-2a.75.75 0 0 1 .75-.75Zm0 5.5A.75.75 0 0 1 9 10v2a.75.75 0 0 1-1.5 0v-2a.75.75 0 0 1 .75-.75Zm0 4.75a.75.75 0 0 1 .75.75v4a.75.75 0 0 1-1.5 0v-4a.75.75 0 0 1 .75-.75ZM14 8.25a.75.75 0 0 1 .75-.75h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1-.75-.75Z"/></svg>');
   --md-admonition-icon--macro: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m5.41 21 .71-4h-4l.35-2h4l1.06-6h-4l.35-2h4l.71-4h2l-.71 4h6l.71-4h2l-.71 4h4l-.35 2h-4l-1.06 6h4l-.35 2h-4l-.71 4h-2l.71-4h-6l-.71 4h-2M9.53 9l-1.06 6h6l1.06-6h-6Z"/></svg>');
 }
 
 .md-typeset .admonition.variable, .md-typeset details.variable,
 .md-typeset .admonition.function, .md-typeset details.function,
+.md-typeset .admonition.typedef, .md-typeset details.typedef,
 .md-typeset .admonition.concept, .md-typeset details.concept,
 .md-typeset .admonition.macro, .md-typeset details.macro {
   border-color: var(--md-default-fg-color--lighter);
@@ -137,6 +139,7 @@ R""""(:root {
 
 .md-typeset .variable > .admonition-title, .md-typeset .variable > summary,
 .md-typeset .function > .admonition-title, .md-typeset .function > summary,
+.md-typeset .typedef > .admonition-title, .md-typeset .typedef > summary,
 .md-typeset .concept > .admonition-title, .md-typeset .concept > summary,
 .md-typeset .macro > .admonition-title, .md-typeset .macro > summary {
   background-color: var(--md-default-bg-color);
@@ -154,6 +157,13 @@ R""""(:root {
   background-color: var(--md-default-fg-color--light);
   -webkit-mask-image: var(--md-admonition-icon--function);
           mask-image: var(--md-admonition-icon--function);
+}
+
+.md-typeset .typedef > .admonition-title::before,
+.md-typeset .typedef > summary::before {
+  background-color: var(--md-default-fg-color--light);
+  -webkit-mask-image: var(--md-admonition-icon--typedef);
+          mask-image: var(--md-admonition-icon--typedef);
 }
 
 .md-typeset .concept > .admonition-title::before,

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -66,6 +66,8 @@ void Entity::addToThis(Entity&& o) {
     groups.push_back(std::move(o));
   } else if (o.type == EntityType::TYPE) {
     types.push_back(std::move(o));
+  } else if (o.type == EntityType::TYPEDEF) {
+    typedefs.push_back(std::move(o));
   } else if (o.type == EntityType::CONCEPT) {
     concepts.push_back(std::move(o));
   } else if (o.type == EntityType::VARIABLE) {
@@ -121,6 +123,7 @@ void Entity::merge(Entity&& o) {
 
   groups.splice(groups.end(), std::move(o.groups));
   types.splice(types.end(), std::move(o.types));
+  typedefs.splice(types.end(), std::move(o.typedefs));
   concepts.splice(concepts.end(), std::move(o.concepts));
   variables.splice(variables.end(), std::move(o.variables));
   functions.splice(functions.end(), std::move(o.functions));

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -15,6 +15,7 @@ enum class EntityType {
   TEMPLATE,
   GROUP,
   TYPE,
+  TYPEDEF,
   CONCEPT,
   VARIABLE,
   FUNCTION,
@@ -103,6 +104,11 @@ struct Entity {
    * Child types.
    */
   list_type types;
+
+  /**
+   * Child typedefs.
+   */
+  list_type typedefs;
 
   /**
    * Child concepts.

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -106,7 +106,7 @@ struct Entity {
   list_type types;
 
   /**
-   * Child typedefs.
+   * Child typedefs and type aliases.
    */
   list_type typedefs;
 

--- a/src/MarkdownGenerator.cpp
+++ b/src/MarkdownGenerator.cpp
@@ -144,7 +144,7 @@ void MarkdownGenerator::generate(const std::filesystem::path& output,
         entity.type == EntityType::NAMESPACE ||
         entity.type == EntityType::GROUP);
     if (typedefs.size() > 0) {
-      out << "## Typedefs" << std::endl;
+      out << "## Typedefs and Type Aliases" << std::endl;
       out << std::endl;
       out << "| Name | Description |" << std::endl;
       out << "| ---- | ----------- |" << std::endl;
@@ -243,7 +243,7 @@ void MarkdownGenerator::generate(const std::filesystem::path& output,
 
     /* detailed descriptions */
     if (typedefs.size() > 0) {
-      out << "## Typedef Details" << std::endl;
+      out << "## Typedef and Type Alias Details" << std::endl;
       out << std::endl;
       for (auto& child : typedefs) {
         out << "### " << child->name;

--- a/src/MarkdownGenerator.cpp
+++ b/src/MarkdownGenerator.cpp
@@ -144,7 +144,7 @@ void MarkdownGenerator::generate(const std::filesystem::path& output,
         entity.type == EntityType::NAMESPACE ||
         entity.type == EntityType::GROUP);
     if (typedefs.size() > 0) {
-      out << "## Typedefs and Type Aliases" << std::endl;
+      out << "## Type Aliases" << std::endl;
       out << std::endl;
       out << "| Name | Description |" << std::endl;
       out << "| ---- | ----------- |" << std::endl;
@@ -243,7 +243,7 @@ void MarkdownGenerator::generate(const std::filesystem::path& output,
 
     /* detailed descriptions */
     if (typedefs.size() > 0) {
-      out << "## Typedef and Type Alias Details" << std::endl;
+      out << "## Type Alias Details" << std::endl;
       out << std::endl;
       for (auto& child : typedefs) {
         out << "### " << child->name;

--- a/src/MarkdownGenerator.cpp
+++ b/src/MarkdownGenerator.cpp
@@ -140,6 +140,21 @@ void MarkdownGenerator::generate(const std::filesystem::path& output,
       out << std::endl;
     }
 
+    auto typedefs = view(entity.typedefs,
+        entity.type == EntityType::NAMESPACE ||
+        entity.type == EntityType::GROUP);
+    if (typedefs.size() > 0) {
+      out << "## Typedefs" << std::endl;
+      out << std::endl;
+      out << "| Name | Description |" << std::endl;
+      out << "| ---- | ----------- |" << std::endl;
+      for (auto& child : typedefs) {
+        out << "| [" << child->name << "](#" << sanitize(child->name) << ") | ";
+        out << line(brief(*child)) << " |" << std::endl;
+      }
+      out << std::endl;
+    }
+
     auto concepts = view(entity.concepts,
         entity.type == EntityType::NAMESPACE ||
         entity.type == EntityType::GROUP);
@@ -227,6 +242,19 @@ void MarkdownGenerator::generate(const std::filesystem::path& output,
     }
 
     /* detailed descriptions */
+    if (typedefs.size() > 0) {
+      out << "## Typedef Details" << std::endl;
+      out << std::endl;
+      for (auto& child : typedefs) {
+        out << "### " << child->name;
+        out << "<a name=\"" << sanitize(child->name) << "\"></a>" << std::endl;
+        out << std::endl;
+        out << "!!! typedef \"" << htmlize(line(child->decl)) << '"' << std::endl;
+        out << std::endl;
+        out << indent(child->docs) << std::endl;
+        out << std::endl;
+      }
+    }
     if (concepts.size() > 0) {
       out << "## Concept Details" << std::endl;
       out << std::endl;


### PR DESCRIPTION
This pull request moves the details of `typedef` statements from their separate pages to a details section in the parents page in the same way as functions, variables, macros, etc. are handled and resolves #35. 