### PR TITLE
Fixing faulty test step on Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,16 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Prepare PowerShell environment
+          command: |
+            # save some env vars to the PS profile on the disk, for them to be sourced in the following runs
+            New-Item $Profile.CurrentUserAllHosts -Force
+            # add cairo path to PATH env variable
+            Add-Content -Path $Profile.CurrentUserAllHosts -Value '$Env:PATH = "$Env:PATH;C:\tools\msys64\ucrt64\bin"'
+            # force error and PS exit on non 0 termination code from command
+            Add-Content -Path $Profile.CurrentUserAllHosts -Value '$ErrorActionPreference = "Stop"'
+            Add-Content -Path $Profile.CurrentUserAllHosts -Value '$PSNativeCommandUseErrorActionPreference = $true'
+      - run:
           name: Checkout submodules
           command: git submodule update --init --recursive --depth 1
       - run:
@@ -116,9 +126,6 @@ jobs:
             C:\tools\msys64\usr\bin\bash -lc 'pacman --noconfirm -Syuu'  # Normal update
             # install cairo
             C:\tools\msys64\usr\bin\bash -lc 'pacman --noconfirm -S mingw-w64-ucrt-x86_64-cairo'
-            # add cairo path to PATH env variable
-            New-Item $Profile.CurrentUserAllHosts -Force
-            Add-Content -Path $Profile.CurrentUserAllHosts -Value '$Env:PATH = "$Env:PATH;C:\tools\msys64\ucrt64\bin"'
             pip3 install mkdocs mkdocs-material mkdocs-material[imaging]
             cd contrib\libyaml
             mkdir build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,18 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            choco install -y cmake.portable python sudo
+            choco upgrade -y chocolatey
+            choco install -y cmake.portable python sudo msys2
+            # Run for the first time
+            C:\tools\msys64\usr\bin\bash -lc ' '
+            # Update MSYS2
+            C:\tools\msys64\usr\bin\bash -lc 'pacman --noconfirm -Syuu'  # Core update
+            C:\tools\msys64\usr\bin\bash -lc 'pacman --noconfirm -Syuu'  # Normal update
+            # install cairo
+            C:\tools\msys64\usr\bin\bash -lc 'pacman --noconfirm -S mingw-w64-ucrt-x86_64-cairo'
+            # add cairo path to PATH env variable
+            New-Item $Profile.CurrentUserAllHosts -Force
+            Add-Content -Path $Profile.CurrentUserAllHosts -Value '$Env:PATH = "$Env:PATH;C:\tools\msys64\ucrt64\bin"'
             pip3 install mkdocs mkdocs-material mkdocs-material[imaging]
             cd contrib\libyaml
             mkdir build


### PR DESCRIPTION
PR after https://github.com/lawmurray/doxide/pull/83#issuecomment-3380847142

IT could be that it's not an upstream issue, as the [installation page of cairosvg](https://cairosvg.org/documentation/#installation) says

> CairoSVG and its dependencies may require additional tools during the installation: a compiler, Python headers, Cairo, and FFI headers. These tools have different names depending on the OS you are using, but:
> on Windows, you’ll have to install Cairo (with [GTK](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer) for example) and Visual C++ compiler for Python;
> on macOS, you’ll have to install cairo and libffi (with [Homebrew](https://brew.sh/) for example);