### PR TITLE
Adding editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+root = true
+
+[*]
+# force UNIX newline, also on Win
+end_of_line = lf
+# useful when cat'ting from the terminal
+insert_final_newline = true
+# useful to minimize git diff
+trim_trailing_whitespace = true
+# consistency across editors
+charset = utf-8
+# consistency across users
+spelling_language = en
+
+[*.{c,cc,cpp,h,hh,hpp,h.in}]
+indent_size = 2
+indent_style = space
+
+[*.cmake]
+indent_size = 2
+indent_style = space
+
+[CMakeLists.txt]
+indent_size = 2
+indent_style = space
+
+[*.nuspec]
+indent_size = 2
+indent_style = space
+
+[*.rb]
+indent_size = 2
+indent_style = space
+
+[*.sh]
+indent_size = 2
+indent_style = space
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(doxide
-    VERSION 0.9.0
-    DESCRIPTION "Modern documentation for modern C++"
-    HOMEPAGE_URL "https://doxide.org"
+  VERSION 0.9.0
+  DESCRIPTION "Modern documentation for modern C++"
+  HOMEPAGE_URL "https://doxide.org"
 )
 cmake_policy(SET CMP0074 NEW) # use <PackageName>_ROOT to look for packages
 
@@ -14,99 +14,98 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 # - target: look for CMake targets, if not found error
 # - auto: (default) first look for CMake targets, if not found, use git submodules
 set(DEPS_STRATEGY_VALUES "auto;submodule;target")
-option(DEPS_SOURCE_STRATEGY "How to source dependencies; possible values are ${DEPS_STRATEGY_VALUES}" OFF)
+option(DEPS_SOURCE_STRATEGY "How to source dependencies;\
+ possible values are ${DEPS_STRATEGY_VALUES}" OFF)
 
 if(NOT DEPS_SOURCE_STRATEGY)
-    set(DEPS_STRATEGY "auto")
+  set(DEPS_STRATEGY "auto")
 else()
-    if(NOT ${DEPS_SOURCE_STRATEGY} IN_LIST DEPS_STRATEGY_VALUES)
-        message(FATAL_ERROR "the value of DEPS_SOURCE_STRATEGY \
+  if(NOT ${DEPS_SOURCE_STRATEGY} IN_LIST DEPS_STRATEGY_VALUES)
+    message(FATAL_ERROR "the value of DEPS_SOURCE_STRATEGY \
 (${DEPS_SOURCE_STRATEGY}) is not one of ${DEPS_STRATEGY_VALUES}"
-        )
-    endif()
-    set(DEPS_STRATEGY ${DEPS_SOURCE_STRATEGY})
+      )
+  endif()
+  set(DEPS_STRATEGY ${DEPS_SOURCE_STRATEGY})
 endif()
 
 if(DEPS_STRATEGY STREQUAL "auto" OR DEPS_STRATEGY STREQUAL "target")
-    set(DEPS_STRATEGY_FIND_PACKAGE ON)
+  set(DEPS_STRATEGY_FIND_PACKAGE ON)
 endif()
 
 if(DEPS_STRATEGY STREQUAL "target")
-    set(FORCED_REQUIRE REQUIRED)
+  set(FORCED_REQUIRE REQUIRED)
 endif()
 
 if(NOT yaml_FOUND AND DEPS_STRATEGY_FIND_PACKAGE)
-    find_package(yaml CONFIG ${FORCED_REQUIRE})
+  find_package(yaml CONFIG ${FORCED_REQUIRE})
 endif()
 if(NOT yaml_FOUND AND NOT DEPS_STRATEGY STREQUAL "submodule")
-    # use Findyaml.cmake module provided and find in system
-    find_package(yaml MODULE)
+  # use Findyaml.cmake module provided and find in system
+  find_package(yaml MODULE)
 endif()
 if(NOT yaml_FOUND)
-    message(STATUS "Sourcing yaml from submodule")
-    add_subdirectory(contrib/libyaml EXCLUDE_FROM_ALL SYSTEM)
+  message(STATUS "Sourcing yaml from submodule")
+  add_subdirectory(contrib/libyaml EXCLUDE_FROM_ALL SYSTEM)
 endif()
 
 # convenience macro to source a dependency: first look for a CMake target (if allowed)
 # then source it from the given files in the submodule
 macro(find_dep_dual_mode dep_name VAR val1)
-    if(NOT ${dep_name}_FOUND AND DEPS_STRATEGY_FIND_PACKAGE)
-        find_package(${dep_name} CONFIG ${FORCED_REQUIRE})
+  if(NOT ${dep_name}_FOUND AND DEPS_STRATEGY_FIND_PACKAGE)
+    find_package(${dep_name} CONFIG ${FORCED_REQUIRE})
+  endif()
+  if(${dep_name}_FOUND)
+    list(APPEND DEPS_TARGETS ${dep_name}::${dep_name})
+  else()
+    set(__the_list ${ARGV})
+    if(${ARGC} GREATER 3)
+      list(SUBLIST __the_list 3 -1 __file_args)
     endif()
-    if(${dep_name}_FOUND)
-        list(APPEND DEPS_TARGETS ${dep_name}::${dep_name})
-    else()
-        set(__the_list ${ARGV})
-        if(${ARGC} GREATER 3)
-            list(SUBLIST __the_list 3 -1 __file_args)
-        endif()
-        message(STATUS "Sourcing ${dep_name} from submodule")
-        list(APPEND ${VAR} ${val1} ${__file_args})
-        unset(__file_args)
-    endif()
+    message(STATUS "Sourcing ${dep_name} from submodule")
+    list(APPEND ${VAR} ${val1} ${__file_args})
+    unset(__file_args)
+  endif()
 endmacro()
 
 find_dep_dual_mode(tree-sitter-cuda DEPS_SOURCES
-    contrib/tree-sitter/lib/src/lib.c contrib/tree-sitter-cuda/src/parser.c contrib/tree-sitter-cuda/src/scanner.c
+  contrib/tree-sitter/lib/src/lib.c contrib/tree-sitter-cuda/src/parser.c
+  contrib/tree-sitter-cuda/src/scanner.c
 )
 if(NOT tree-sitter-cuda_FOUND)
-    list(APPEND DEPS_INCLUDE_DIRS contrib/tree-sitter/lib/include)
+  list(APPEND DEPS_INCLUDE_DIRS contrib/tree-sitter/lib/include)
 endif()
 
 find_dep_dual_mode(CLI11 DEPS_INCLUDE_DIRS contrib/CLI11/include)
 find_dep_dual_mode(p-ranav-glob DEPS_INCLUDE_DIRS contrib/glob/single_include)
 
 add_executable(doxide
-    ${DEPS_SOURCES} # sources of the submodules (if any)
-    src/doxide.cpp
-    src/CppParser.cpp
-    src/Doc.cpp
-    src/DocToken.cpp
-    src/DocTokenizer.cpp
-    src/Driver.cpp
-    src/Entity.cpp
-    src/GcovCounter.cpp
-    src/JSONCounter.cpp
-    src/JSONGenerator.cpp
-    src/MarkdownGenerator.cpp
-    src/SourceWatcher.cpp
-    src/YAMLNode.cpp
-    src/YAMLParser.cpp
+  ${DEPS_SOURCES} # sources of the submodules (if any)
+  src/doxide.cpp
+  src/CppParser.cpp
+  src/Doc.cpp
+  src/DocToken.cpp
+  src/DocTokenizer.cpp
+  src/Driver.cpp
+  src/Entity.cpp
+  src/GcovCounter.cpp
+  src/JSONCounter.cpp
+  src/JSONGenerator.cpp
+  src/MarkdownGenerator.cpp
+  src/SourceWatcher.cpp
+  src/YAMLNode.cpp
+  src/YAMLParser.cpp
 )
 if(WIN32)
-    # add icon
-    target_sources(doxide PRIVATE win/icon.rc)
+  # add icon
+  target_sources(doxide PRIVATE win/icon.rc)
 endif()
-target_include_directories(doxide PRIVATE
-    src
-    ${DEPS_INCLUDE_DIRS}
-)
+target_include_directories(doxide PRIVATE src ${DEPS_INCLUDE_DIRS})
 
 target_link_libraries(doxide yaml ${DEPS_TARGETS})
 
 configure_file(
-    ${CMAKE_SOURCE_DIR}/src/config.h.in
-    ${CMAKE_SOURCE_DIR}/src/config.h
+  ${CMAKE_SOURCE_DIR}/src/config.h.in
+  ${CMAKE_SOURCE_DIR}/src/config.h
 )
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Adding an `.editorconfig` file to the repo root. The file `CMakeLists.txt` is also correspondingly re-indented for consistency.

---

In case you are not familiar with `.editorconfig` files, it is a file storing **basic** settings for indenting code and styling files that IDEs can load and apply **during code writing**: instead of, e.g., inferring indentation settings (tabs vs spaces, how many spaces) from previous lines (which can be confusing if it is not consistent) or relying on the user setting this every time, an IDE reads the `.editorconfig` file in the project root and gets this info. This way, when the user types code and, e.g., types a new line, the IDE automatically applies the right indentation (2 spaces).

Settings affecting all files are stored in the section `[*]`, while file-specific settings are stored in separate sections, possibly with wildcards to apply to all files with, e.g., a certain extension, like `[*.{c,cc,cpp,h,hh,hpp,h.in}]` for all C++ files.

It is hierarchical w.r.t. the filesystem: the settings in the deepest `.editorconfig` file (with `root = false`) apply, for example, to override some default behaviour on certain files in a subfolder.

All in all, an `.editorconfig` just ensures the basics, helps developers remain consistent and keeps things cleaner for `git diff`s (for example, by trimming trailing whitespaces automatically). Instead, `clang-format` does the "heavy lifting" on the code, because it actually understands its structure, and is kind-of a "post-processing" step. However, while `clang-format` is only for C/C++, `.editorconfig` can store settings for any file type.