### PR TITLE
#55 tracking line for ingroup across entities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ add_executable(doxide
   src/JSONGenerator.cpp
   src/MarkdownGenerator.cpp
   src/SourceWatcher.cpp
+  src/TextLineCursor.cpp
   src/YAMLNode.cpp
   src/YAMLParser.cpp
 )

--- a/src/CppParser.cpp
+++ b/src/CppParser.cpp
@@ -848,10 +848,10 @@ void CppParser::report(const std::filesystem::path& filename,
     uint32_t l = ts_node_end_byte(node);
     TSPoint from = ts_node_start_point(node);
     if (ts_node_is_error(node)) {
-      std::cerr << filename << ':' << (from.row + 1) << ':' << from.column <<
+      warn(filename << ':' << (from.row + 1) << ':' << from.column <<
           ": warning: parse error at '" <<
           in.substr(k, std::min(l - k, 40u)) <<
-          "', but will continue" << std::endl;
+          "', but will continue");
     }
 
     /* next node */

--- a/src/CppParser.cpp
+++ b/src/CppParser.cpp
@@ -1,9 +1,10 @@
 #include "CppParser.hpp"
 #include "Doc.hpp"
+#include "TextLineCursor.hpp"
 
 /**
  * Query for entities in C++ sources.
- * 
+ *
  * @ingroup developer
  */
 static const char* query_cpp = R""""(
@@ -366,7 +367,7 @@ static const char* query_cpp = R""""(
 
 /**
  * Query for entities to explicitly exclude from  line counts in C++ sources.
- * 
+ *
  * @ingroup developer
  */
 static const char* query_cpp_exclude = R""""(
@@ -400,7 +401,7 @@ static const char* query_cpp_exclude = R""""(
 
 /**
  * Query for entities to explicitly include in line counts in C++ sources.
- * 
+ *
  * @ingroup developer
  */
 static const char* query_cpp_include = R""""(
@@ -495,17 +496,19 @@ void CppParser::parse(const std::filesystem::path& filename,
   file.end_line = 0;
   file.type = EntityType::FILE;
   file.visible = true;
+  TextLineCursor file_content(file.decl);
+
 
   /* parse */
-  TSTree* tree = ts_parser_parse_string(parser, NULL, file.decl.data(),
-      uint32_t(file.decl.size()));
+  TSTree* tree = ts_parser_parse_string(parser, NULL, file_content.data(),
+      uint32_t(file_content.size()));
   if (!tree) {
     /* something went very wrong */
     warn("cannot parse " << filename << ", skipping");
     return;
   } else {
     /* report on any remaining parse errors */
-    report(filename, file.decl, tree);
+    report(filename, file_content.view(), tree);
   }
 
   /* query entity information */
@@ -523,19 +526,19 @@ void CppParser::parse(const std::filesystem::path& filename,
   TSQueryMatch match;
   Entity entity;
   int indent = 0;
-  while (ts_query_cursor_next_match(cursor, &match)) {    
+  while (ts_query_cursor_next_match(cursor, &match)) {
     uint32_t start = 0, middle = 0, end = 0;
     uint32_t start_line = -1, end_line = -1;
     for (uint16_t i = 0; i < match.capture_count; ++i) {
       node = match.captures[i].node;
-      uint32_t id = match.captures[i].index; 
+      uint32_t id = match.captures[i].index;
       uint32_t length = 0;
       const char* name = ts_query_capture_name_for_id(query, id, &length);
       uint32_t k = ts_node_start_byte(node);
       uint32_t l = ts_node_end_byte(node);
 
       if (strncmp(name, "docs", length) == 0) {
-        Doc doc(file.decl.substr(k, l - k), indent);
+        Doc doc(file_content.substr(k, l - k), indent);
         Entity& e = doc.open.type == OPEN_BEFORE ? entity : entities.back();
         e.docs.append(doc.docs);
         e.hide = e.hide || doc.hide;
@@ -554,7 +557,7 @@ void CppParser::parse(const std::filesystem::path& filename,
          * name on `::`, push namespaces for the first n - 1 identifiers, and
          * assign the last as the name of this entity */
         static const std::regex sep("\\s*::\\s*", regex_flags);
-        
+
         /* load into a std::string and use std::sregex_token_iterator;
          * maintaining the std::string_view and using
          * std::cregex_token_iterator seems to have memory issues when mixed
@@ -569,6 +572,7 @@ void CppParser::parse(const std::filesystem::path& filename,
           Entity parent;
           parent.type = EntityType::NAMESPACE;
           parent.name = prev;
+          parent.path = filename;
 
           push(std::move(parent), start, end);
           prev = *ns_iter;
@@ -625,7 +629,7 @@ void CppParser::parse(const std::filesystem::path& filename,
       }
 
       entity.decl = file.decl.substr(start, middle - start);
-      entity.path = filename;
+      entity.path = filename; // set in case of error, to report the file
       entity.start_line = start_line;
       entity.end_line = end_line;
       entity.visible = !entity.docs.empty();
@@ -671,10 +675,10 @@ void CppParser::parse(const std::filesystem::path& filename,
   cursor = ts_query_cursor_new();
   node = ts_tree_root_node(tree);
   ts_query_cursor_exec(cursor, query_exclude, node);
-  while (ts_query_cursor_next_match(cursor, &match)) {    
+  while (ts_query_cursor_next_match(cursor, &match)) {
     for (uint16_t i = 0; i < match.capture_count; ++i) {
       node = match.captures[i].node;
-      uint32_t id = match.captures[i].index; 
+      uint32_t id = match.captures[i].index;
       uint32_t length = 0;
       uint32_t start = ts_node_start_byte(node);
       uint32_t end = ts_node_end_byte(node);
@@ -706,7 +710,7 @@ void CppParser::parse(const std::filesystem::path& filename,
   while (ts_query_cursor_next_match(cursor, &match)) {
     for (uint16_t i = 0; i < match.capture_count; ++i) {
       node = match.captures[i].node;
-      uint32_t id = match.captures[i].index; 
+      uint32_t id = match.captures[i].index;
       uint32_t length = 0;
       uint32_t start = ts_node_start_byte(node);
       uint32_t end = ts_node_end_byte(node);
@@ -737,7 +741,7 @@ void CppParser::parse(const std::filesystem::path& filename,
   /* finish up */
   root.add(std::move(file));
   ts_tree_delete(tree);
-  ts_parser_reset(parser);  
+  ts_parser_reset(parser);
 
   assert(entities.empty());
   assert(starts.empty());
@@ -835,7 +839,7 @@ std::string CppParser::preprocess(const std::filesystem::path& filename,
 }
 
 void CppParser::report(const std::filesystem::path& filename,
-    const std::string& in, TSTree* tree) {
+    const std::string_view in, TSTree* tree) {
   TSNode root = ts_tree_root_node(tree);
   TSNode node = root;
   TSTreeCursor cursor = ts_tree_cursor_new(root);

--- a/src/CppParser.hpp
+++ b/src/CppParser.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <string_view>
+
 #include "doxide.hpp"
 #include "Entity.hpp"
 
 /**
  * C++ source parser.
- * 
+ *
  * @ingroup developer
  */
 class CppParser {
@@ -22,7 +24,7 @@ public:
 
   /**
    * Parse C++ source.
-   * 
+   *
    * @param file C++ source file name.
    * @param defines Macro definitions.
    * @param[in,out] root Root entity.
@@ -34,7 +36,7 @@ public:
 private:
   /**
    * Push onto the stack.
-   * 
+   *
    * @param entity Entity to push.
    * @param start Start byte of range.
    * @param end End byte of range.
@@ -44,12 +46,12 @@ private:
   /**
    * Pop the stack down to the parent of an entity, according to its byte
    * range.
-   * 
+   *
    * @param start Start byte of range.
    * @param end End byte of range.
-   * 
+   *
    * @return The parent.
-   * 
+   *
    * If both @p start and @p end are zero, this is interpreting as popping the
    * stack down to the root node and returning it.
    */
@@ -71,12 +73,12 @@ private:
 
   /**
    * Report errors after preprocessing.
-   * 
+   *
    * @param file C++ source file name.
    * @param in Preprocessed source.
    * @param tree Parse tree for file.
    */
-  void report(const std::filesystem::path& file, const std::string& in,
+  void report(const std::filesystem::path& file, const std::string_view in,
       TSTree* tree);
 
   /**
@@ -88,7 +90,7 @@ private:
    * Stack of start bytes, corresponding to `entities`, while parsing.
    */
   std::list<uint32_t> starts;
-  
+
   /**
    * Stack of end bytes, corresponding to `entities`, while parsing.
    */

--- a/src/Doc.cpp
+++ b/src/Doc.cpp
@@ -16,31 +16,32 @@ Doc::Doc(const TextLineCursor &comment, const int init_indent) :
       indent = std::max(indent - 4, 0);
     } else while (token.type) {
       if (token.type & COMMAND) {
-        std::string_view command = token.substr(1);
+        auto command_token = token.substr(1);
+        std::string_view command = command_token.view();
         if (command == "param" ||
             command == "param[in]") {
           docs.append("\n:material-location-enter: `");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("`\n:   ");
           indent = 4;
         } else if (command == "param[out]") {
           docs.append("\n:material-location-exit: `");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("`\n:   ");
           indent = 4;
         } else if (command == "param[in,out]") {
           docs.append("\n:material-location-enter::material-location-exit: `");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("`\n:   ");
           indent = 4;
         } else if (command == "tparam") {
           docs.append("\n:material-code-tags: `");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("`\n:   ");
           indent = 4;
         } else if (command == "p") {
           docs.append("`");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("`");
         } else if (command == "return") {
           docs.append("\n:material-keyboard-return: **Return**\n:   ");
@@ -54,7 +55,7 @@ Doc::Doc(const TextLineCursor &comment, const int init_indent) :
           docs.append("\n:material-eye-outline: **See**\n:   ");
         } else if (command == "anchor") {
           docs.append("<a name=\"");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("\"></a>");
         } else if (command == "note" ||
             command == "abstract" ||
@@ -88,15 +89,15 @@ Doc::Doc(const TextLineCursor &comment, const int init_indent) :
             command == "em" ||
             command == "a") {
           docs.append("*");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("*");
         } else if (command == "b") {
           docs.append("**");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("**");
         } else if (command == "c") {
           docs.append("`");
-          docs.append(tokenizer.consume(WORD).str());
+          docs.append(tokenizer.consume(WORD).view());
           docs.append("`");
         } else if (command == "f$") {
           docs.append("$");
@@ -110,9 +111,9 @@ Doc::Doc(const TextLineCursor &comment, const int init_indent) :
           auto href = tokenizer.consume(WORD);
           auto text = tokenizer.consume(WORD);
           docs.append("[");
-          docs.append(text.str());
+          docs.append(text.view());
           docs.append("](#");
-          docs.append(href.str());
+          docs.append(href.view());
           docs.append(")");
         } else if (command == "code" ||
             command == "endcode" ||
@@ -149,17 +150,19 @@ Doc::Doc(const TextLineCursor &comment, const int init_indent) :
           docs.append("@");
         } else if (command == "/") {
           docs.append("/");
-        } else if (token.str().at(0) == '\\') {
+        } else if (token.view().at(0) == '\\') {
           /* unrecognized command starting with legacy backslash, could just
            * be e.g. a LaTeX macro, output as is */
-          docs.append(token.str());
+          docs.append(token.view());
         } else {
           /* keep track of warnings and don't repeat them */
           static std::unordered_set<std::string> warned;
           if (warned.insert(std::string(command)).second) {
-            warn("unrecognized command: " << command);
+            warn("line " << command_token.get_line_number()
+              << ": unrecognized command '" << command << "'");
           }
-          docs.append(token.str());
+          docs.append(token.view
+            ());
         }
       } else if (token.type & PARA) {
         if (!first) {
@@ -175,7 +178,7 @@ Doc::Doc(const TextLineCursor &comment, const int init_indent) :
         //
       } else {
         docs.append(first*indent, ' ');  // indent on first token
-        docs.append(token.str());
+        docs.append(token.view());
       }
       token = tokenizer.next();
       first = false;

--- a/src/Doc.cpp
+++ b/src/Doc.cpp
@@ -1,7 +1,7 @@
 #include "Doc.hpp"
 #include "DocTokenizer.hpp"
 
-Doc::Doc(const std::string_view comment, const int init_indent) :
+Doc::Doc(const TextLineCursor &comment, const int init_indent) :
     indent(init_indent),
     hide(false) {
   DocTokenizer tokenizer(comment);
@@ -73,7 +73,7 @@ Doc::Doc(const std::string_view comment, const int init_indent) :
           docs.append("\n");
           indent += 4;
         } else if (command == "ingroup") {
-          ingroup = tokenizer.consume(WORD).str();
+          ingroup = tokenizer.consume(WORD).get();
 
         /* legacy commands */
         } else if (command == "returns" ||

--- a/src/Doc.hpp
+++ b/src/Doc.hpp
@@ -2,20 +2,21 @@
 
 #include "doxide.hpp"
 #include "DocToken.hpp"
+#include "TextLineCursor.hpp"
 
 /**
  * Documentation of an entity.
- * 
+ *
  * @ingroup developer
  */
 struct Doc {
   /**
    * Constructor.
-   * 
+   *
    * @param comment Comment from which to populate documentation.
    * @param init_indent Initial indent level.
    */
-  Doc(const std::string_view comment, const int init_indent);
+  Doc(const TextLineCursor &comment, const int init_indent);
 
   /**
    * Content of the documentation.
@@ -26,7 +27,7 @@ struct Doc {
    * Group to which the entity belongs, obtained from @ingroup in the
    * documentation comment.
    */
-  std::string ingroup;
+  TextLineCursor ingroup;
 
   /**
    * Opening token, used to determine the type of comment.

--- a/src/DocToken.cpp
+++ b/src/DocToken.cpp
@@ -12,13 +12,13 @@ const TextLineCursor& DocToken::get() const {
 }
 
 
-std::string_view DocToken::str() const {
+std::string_view DocToken::view() const {
   /* std::string_view(first, last) ought to work with C++20 support, but
    * using the below overload of the constructor extends support to some
    * older compilers, such as gcc with gnu++2a support only, and MSVC 2022 */
   return value.view();
 }
 
-std::string_view DocToken::substr(size_t pos) const {
-  return value.view().substr(pos);
+TextLineCursor DocToken::substr(size_t pos) const {
+  return value.substr(pos);
 }

--- a/src/DocToken.cpp
+++ b/src/DocToken.cpp
@@ -1,18 +1,24 @@
 #include "DocToken.hpp"
 
-DocToken::DocToken(const DocTokenType type, const std::string_view value) :
+DocToken::DocToken(const DocTokenType type, const TextLineCursor value) :
     type(type),
     value(value) {
   //
 }
 
+
+const TextLineCursor& DocToken::get() const {
+  return value;
+}
+
+
 std::string_view DocToken::str() const {
   /* std::string_view(first, last) ought to work with C++20 support, but
    * using the below overload of the constructor extends support to some
    * older compilers, such as gcc with gnu++2a support only, and MSVC 2022 */
-  return value;
+  return value.view();
 }
 
 std::string_view DocToken::substr(size_t pos) const {
-  return value.substr(pos);
+  return value.view().substr(pos);
 }

--- a/src/DocToken.hpp
+++ b/src/DocToken.hpp
@@ -74,14 +74,14 @@ struct DocToken {
   /**
    * Get token as string.
    */
-  std::string_view str() const;
+  std::string_view view() const;
 
   /**
    * Get substring of the token as a string.
    *
    * @param pos Position of the first character.
    */
-  std::string_view substr(size_t pos = 0) const;
+  TextLineCursor substr(size_t pos = 0) const;
 
   /**
    * Token type.

--- a/src/DocToken.hpp
+++ b/src/DocToken.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "doxide.hpp"
+#include "TextLineCursor.hpp"
 
 /**
  * Documentation comment token types. Closing delimiters must be one shift
@@ -52,21 +53,23 @@ static auto regexes = {
 
 /**
  * Token.
- * 
+ *
  * @ingroup developer
- * 
+ *
  * A token is only valid for the lifetime of the Tokenizer that produced it,
  * as it contains a reference to a substring of the source file.
  */
 struct DocToken {
   /**
    * Constructor.
-   * 
+   *
    * @param type Token type.
    * @param value Token value.
    */
   DocToken(const DocTokenType type = NONE,
-      std::string_view value = std::string_view());
+      TextLineCursor value = TextLineCursor());
+
+  const TextLineCursor& get() const;
 
   /**
    * Get token as string.
@@ -75,7 +78,7 @@ struct DocToken {
 
   /**
    * Get substring of the token as a string.
-   * 
+   *
    * @param pos Position of the first character.
    */
   std::string_view substr(size_t pos = 0) const;
@@ -88,5 +91,5 @@ struct DocToken {
   /**
    * Iterator to first character.
    */
-  std::string_view value;
+  TextLineCursor value;
 };

--- a/src/DocTokenizer.cpp
+++ b/src/DocTokenizer.cpp
@@ -1,20 +1,21 @@
 #include "DocTokenizer.hpp"
 
-DocTokenizer::DocTokenizer(const std::string_view& source) {
-  iter = source.cbegin();
-  end = source.cend();
-}
+DocTokenizer::DocTokenizer(const TextLineCursor& src): source(src) {}
 
 DocToken DocTokenizer::next() {
   DocToken token;
+  auto iter = source.cbegin();
+  auto end = source.cend();
   if (iter != end) {
     for (auto& [type, regex] : regexes) {
-      std::match_results<std::string_view::const_iterator> match;
+      std::match_results<TextLineCursor::const_iterator> match;
       if (std::regex_search(iter, end, match, regex,
           std::regex_constants::match_continuous)) {
         token.type = type;
-        token.value = std::string_view(iter, iter + match.length());
-        iter += match.length();
+        // token.value = std::string_view(iter, iter + match.length());
+        token.value = source.substr(iter, match.length());
+        // iter += match.length();
+        source.advance(match.length());
         return token;
       }
     }
@@ -27,6 +28,6 @@ DocToken DocTokenizer::consume(const int stop) {
   DocToken token = next();
   while (token.type && !(token.type & stop)) {
     token = next();
-  }    
+  }
   return token;
 }

--- a/src/DocTokenizer.hpp
+++ b/src/DocTokenizer.hpp
@@ -2,21 +2,22 @@
 
 #include "doxide.hpp"
 #include "DocToken.hpp"
+#include "TextLineCursor.hpp"
 
 /**
  * Documentation comment tokenizer.
- * 
+ *
  * @ingroup developer
  */
 class DocTokenizer {
 public:
   /**
    * Constructor.
-   * 
+   *
    * @param comment Comment to tokenize.
    */
-  DocTokenizer(const std::string_view& source);
-  
+  DocTokenizer(const TextLineCursor& source);
+
   /**
    * Get the next token.
    *
@@ -31,11 +32,11 @@ public:
 
   /**
    * Consume tokens until stopping criterion.
-   * 
+   *
    * @param stop Bitmask giving the token types on which to stop and return.
-   * 
+   *
    * @return Last token consumed.
-   * 
+   *
    * Tokens are consumed until one is encountered with a type in @p stop,
    * which is then returned. If @p stop is `ANY` then the next token is
    * returned.
@@ -43,13 +44,6 @@ public:
   DocToken consume(const int stop = ANY);
 
 private:
-  /**
-   * Iterator over source.
-   */
-  std::string_view::const_iterator iter;
 
-  /**
-   * End of source.
-   */
-  std::string_view::const_iterator end;
+  TextLineCursor source;
 };

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -22,9 +22,10 @@ void Entity::add(Entity&& o) {
     } else {
       /* keep track of warnings and don't repeat them */
       static std::unordered_set<std::string> warned;
-      if (warned.insert(o.ingroup).second) {
-        warn("unrecognized group " << o.ingroup <<
-            ", groups must be defined in config file, ignoring @ingroup");
+      if (warned.insert(o.ingroup.to_string()).second) {
+        warn("file " << o.path << " line " << o.ingroup.get_line_number() <<
+            ": unrecognized group '" << o.ingroup.view() <<
+            "', groups must be defined in config file, ignoring @ingroup");
       }
     }
   }

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -13,7 +13,8 @@ Entity::Entity() :
 
 void Entity::add(Entity&& o) {
   if (o.type == EntityType::NAMESPACE && !o.ingroup.empty()) {
-    warn("namespace cannot have @ingroup, ignoring");
+    warn("file " << o.path << " line " << o.ingroup.get_line_number() <<
+        "namespace cannot have @ingroup, ignoring");
     o.ingroup.clear();
   }
   if (!o.ingroup.empty()) {

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -4,9 +4,11 @@
 
 #include <filesystem>
 
+#include "TextLineCursor.hpp"
+
 /**
  * Entity types.
- * 
+ *
  * @ingroup developer
  */
 enum class EntityType {
@@ -28,7 +30,7 @@ enum class EntityType {
 
 /**
  * Entity in a C++ source file, e.g. variable, function, class, etc.
- * 
+ *
  * @ingroup developer
  */
 struct Entity {
@@ -45,9 +47,9 @@ struct Entity {
 
   /**
    * Add child entity.
-   * 
+   *
    * @param o Child entity.
-   * 
+   *
    * If the child has `ingroup` set, then will search for and add to that
    * group instead.
    */
@@ -55,14 +57,14 @@ struct Entity {
 
   /**
    * Merge the children of another entity into this one.
-   * 
+   *
    * @param o Other entity.
    */
   void merge(Entity&& o);
 
   /**
    * Does a file exist of the given name?
-   * 
+   *
    * @param path File path.
    */
   bool exists(std::filesystem::path& path) const;
@@ -180,7 +182,7 @@ struct Entity {
   /**
    * Group to which this belongs.
    */
-  std::string ingroup;
+  TextLineCursor ingroup;
 
   /**
    * Path of source file.
@@ -232,9 +234,9 @@ struct Entity {
 private:
   /**
    * Add child entity to a group.
-   * 
+   *
    * @param o Child entity with `ingroup` set.
-   * 
+   *
    * @return True if a group of the given name was found, in which case @p o
    * will have been added to it, false otherwise.
    */
@@ -242,9 +244,9 @@ private:
 
   /**
    * Add child entity.
-   * 
+   *
    * @param o Child entity.
-   * 
+   *
    * If the child has `ingroup` set, it is ignored.
    */
   void addToThis(Entity&& o);

--- a/src/TextLineCursor.cpp
+++ b/src/TextLineCursor.cpp
@@ -1,0 +1,103 @@
+#include <TextLineCursor.hpp>
+
+#include <stdexcept>
+#include <algorithm>
+#include <compare>
+
+TextLineCursor::TextLineCursor(): _start(nullptr), _size(0), _line_num(0) {}
+
+TextLineCursor::TextLineCursor(const char* start, std::size_t size, std::size_t line_num):
+  _start(start), _size(size), _line_num(line_num) {}
+
+TextLineCursor::TextLineCursor(const std::string_view &v): TextLineCursor(v.data(), v.size(), 0) {}
+
+TextLineCursor::TextLineCursor(const std::string &v) : TextLineCursor(v.data(), v.size(), 0) {}
+
+void TextLineCursor::advance(std::size_t length) {
+  check_length(length);
+  _line_num += _do_count_lines_in_range(cbegin(), cbegin() + length);
+  _start += length;
+  _size -= length;
+}
+
+void TextLineCursor::clear() noexcept {
+  _start = nullptr;
+  _size = 0;
+  _line_num = 0;
+}
+
+
+void TextLineCursor::check_start(const_iterator start) const {
+  if (start < cbegin()) {
+    throw std::out_of_range("start is before beginning");
+  }
+  if (start > cend()) {
+    throw std::out_of_range("start is beyond size");
+  }
+}
+
+void TextLineCursor::check_length(std::size_t length) const {
+  if (length > size()) {
+    throw std::out_of_range("length is beyond size");
+  }
+}
+
+void TextLineCursor::check_end(const_iterator end) const {
+  if (end > cend()) {
+    throw std::out_of_range("end is beyond text");
+  }
+}
+
+void TextLineCursor::check_range(std::size_t start, std::size_t length) const {
+  check_start(cbegin() + start);
+  check_length(start + length);
+}
+
+void TextLineCursor::check_range(const_iterator start, std::size_t length) const {
+  check_start(start);
+  check_end(start + length);
+}
+
+void TextLineCursor::check_range(const_iterator start, const_iterator end) const {
+  if (end < start) {
+    throw std::out_of_range("end is before start");
+  }
+  check_start(start);
+  check_end(end);
+}
+
+std::size_t TextLineCursor::count_lines_in_range(const_iterator start, const_iterator end) const {
+  check_range(start, end);
+  return _do_count_lines_in_range(start, end);
+}
+
+std::size_t TextLineCursor::count_lines_in_range(const_iterator start, std::size_t length) const {
+  return count_lines_in_range(start, start + length);
+}
+
+std::size_t TextLineCursor::count_lines_in_range(std::size_t start, std::size_t length) const {
+  const char* _begin = _start + start;
+  return count_lines_in_range(_begin, _begin + length);
+}
+
+std::size_t TextLineCursor::_do_count_lines_in_range(const_iterator start, const_iterator end) const {
+  return std::count(start, end, '\n');
+}
+
+TextLineCursor TextLineCursor::substr(std::size_t start, std::size_t size) const {
+  check_range(start, size);
+  auto res = TextLineCursor(cbegin() + start, size, _line_num + count_lines_in_range(cbegin(), start));
+  return res;
+}
+
+TextLineCursor TextLineCursor::substr(std::size_t start) const {
+  std::size_t len = size() - start;
+  check_range(start, len);
+  auto res = TextLineCursor(cbegin() + start, len, _line_num + count_lines_in_range(cbegin(), start));
+  return res;
+}
+
+TextLineCursor TextLineCursor::substr(const_iterator start, std::size_t length) const {
+  check_range(start, length);
+  return TextLineCursor(start, length, _line_num + count_lines_in_range(cbegin(), start));
+}

--- a/src/TextLineCursor.hpp
+++ b/src/TextLineCursor.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <string_view>
+#include <string>
+#include <ostream>
+#include <format>
+#include <stdexcept>
+#include <utility>
+
+/**
+ * Allows cursoring through external text keeping track of the line number.
+ *
+ * @ingroup developer
+ */
+class TextLineCursor {
+public:
+
+  using iterator = const char*;
+  using const_iterator = const char*;
+
+  /**
+   * Construct an empty cursor.
+   */
+  TextLineCursor();
+
+  /**
+   * Constructor from string_view.
+   *
+   * @param v text tu cursor on.
+   */
+  explicit TextLineCursor(const std::string_view &v);
+
+  /**
+   * Constructor from string.
+   *
+   * @param v text tu cursor on.
+   */
+  explicit TextLineCursor(const std::string &v);
+
+  /**
+   * Constructor from string_view.
+   *
+   * @param v text tu cursor on.
+   */
+  TextLineCursor(const TextLineCursor &) = default;
+
+  TextLineCursor& operator=(const TextLineCursor &) = default;
+
+  inline char operator[](std::size_t i) const noexcept { return _start[i]; }
+
+  /**
+   * Get the pointer to the underlying data.
+   */
+  inline const char* data() const noexcept { return _start; }
+
+  /**
+   * Get the number of the current line: *it is 0-based*.
+   */
+  inline std::size_t get_line_number() const noexcept { return _line_num; }
+
+  /**
+   * Get the number of characters in the text.
+   */
+  inline std::size_t size() const noexcept { return _size; }
+
+  /**
+   * Get the text as a string_view.
+   */
+  inline std::string_view view() const noexcept {
+    return std::string_view(data(), size());
+  }
+
+  inline bool empty() const noexcept { return size() == 0; }
+
+  /**
+   * Creates a (separate) sub-text of the current text.
+   *
+   * @param start start offset of the new sub-text
+   * @param length length of the new sub-text
+   */
+  TextLineCursor substr(std::size_t start, std::size_t length) const;
+
+  /**
+   * Creates a (separate) sub-text of the current text from the given start
+   * to the current length of the text.
+   *
+   * @param start start offset of the new sub-text
+   */
+  TextLineCursor substr(std::size_t start) const;
+
+  /**
+   * Creates a (separate) sub-text of the current text from a start position
+   * (passed as an iterator) and for a given length.
+   *
+   * @param start start position of the new sub-text
+   * @param length length of the new sub-text
+   * @return TextLineCursor
+   */
+  TextLineCursor substr(const_iterator start, std::size_t length) const;
+
+  inline const char* begin() const noexcept { return _start; }
+
+  inline const char* cbegin() const noexcept { return _start; }
+
+  inline const char* end() const noexcept { return _start + _size; }
+
+  inline const char* cend() const noexcept { return _start + _size; }
+
+  /**
+   * Converst to string.
+   */
+  inline std::string to_string() const noexcept { return std::string(cbegin(), cend()); }
+
+  /**
+   * Advance the cursor by length characters; it throws out_of_range if `length`
+   * is higher that `size()`.
+   */
+  void advance(std::size_t length);
+
+  /**
+   * Clears the current cursor.
+   */
+  void clear() noexcept;
+
+private:
+  const char* _start;
+  std::size_t _size;
+  std::size_t _line_num;
+
+  TextLineCursor(const char* start, std::size_t size, std::size_t line_start);
+
+  void check_start(const_iterator start) const;
+
+  void check_length(std::size_t length) const;
+
+  void check_end(const_iterator end) const;
+
+  void check_range(std::size_t start, std::size_t length) const;
+
+  void check_range(const_iterator start, std::size_t length) const;
+
+  void check_range(const_iterator start, const_iterator end) const;
+
+  std::size_t count_lines_in_range(const_iterator start, const_iterator end) const;
+
+  std::size_t count_lines_in_range(const_iterator start, std::size_t length) const;
+
+  std::size_t count_lines_in_range(std::size_t start, std::size_t length) const;
+
+  // unsafe version, without boundaries checks
+  std::size_t _do_count_lines_in_range(const_iterator start, const_iterator end) const;
+};
+
+/**
+ * Compares the text in the view `v` against that in the cursor `w`.
+ */
+inline bool operator==(const std::string_view& v, const TextLineCursor& w) { return v == w.view(); }
+
+/**
+ * Allows printing the cursor `v` into the stream `s`.
+ */
+inline std::ostream& operator<<(std::ostream& s, const TextLineCursor& v) { return s << v.view(); }

--- a/src/TextLineCursor.hpp
+++ b/src/TextLineCursor.hpp
@@ -3,8 +3,6 @@
 #include <string_view>
 #include <string>
 #include <ostream>
-#include <format>
-#include <stdexcept>
 #include <utility>
 
 /**


### PR DESCRIPTION
This PR adds a dedicated class to track and advance the position of a sub-string and store line information. This class is used to store the `ingroup` information.